### PR TITLE
Update script for new history database

### DIFF
--- a/brewblox_to_brewfather.example.yml
+++ b/brewblox_to_brewfather.example.yml
@@ -1,12 +1,10 @@
 brewblox:
-  url: https://brewpi/history/query/last_values            # URL of brewblox install
-  devices:                                                 # List of Brewblox "measurement" devices
-    - spark-one:
-        temp: "Ferment Beer Sensor/value[degC]"            # Every item is defined as with the brewfather variable as key
-        aux_temp: "Ferment Fridge Sensor/value[degC]"      # and the Breblox variable name as value
-        ext_temp: "Kamertemperatuur sensor/value[degC]"
-    - tilt:                                                # https://github.com/j616/brewblox-tilt
-        gravity: "Blue/Specific gravity"
+  url: https://brewpi                                            # URL of brewblox install
+  fields:                                                        # List of Brewblox services
+    temp: "spark-one/Ferment Beer Sensor/value[degC]"            #   Every item is defined with the brewfather variable as key
+    aux_temp: "spark-one/Ferment Fridge Sensor/value[degC]"      #   and the Brewblox variable name as value
+    ext_temp: "spark-one/Kamertemperatuur sensor/value[degC]"    #   Brewblox variables are formatted as {service}/{field}
+    gravity: "tilt/Blue/Specific gravity"                        # https://github.com/BrewBlox/brewblox-tilt
 
 brewfather:
   url: http://log.brewfather.net/stream?id=XXXXXXXXXXXXXX  # replace with your URL from brewfather settings page (Custom Stream)

--- a/brewblox_to_brewfather.py
+++ b/brewblox_to_brewfather.py
@@ -1,75 +1,76 @@
 #!/usr/bin/python3
-import yaml
-import json
+import datetime
+import os
+import sys
+import time
+
 import requests
 import urllib3
-import time
-import datetime
-import sys
-import os
+import yaml
 
-# Search key of fields based on value
-def fieldSearch(value):
-    for k,v in fields.items():
-        if v == value:
-            return k
-    return False
-
-# Don't submit Null/None data
-def removeNone(d):
-    out = {}
-    for k,v in d.items():
-        if(v != 'None'):
-            out[k] = v
-    return out
+urllib3.disable_warnings()
 
 # Load and process config file
 try:
-    yamlfile = open(os.path.join(sys.path[0], "brewblox_to_brewfather.yml"))
+    yamlfile = open(os.path.join(sys.path[0], 'brewblox_to_brewfather.yml'))
     conf = yaml.safe_load(yamlfile)
-except:
-    print("Error loading confiration file brewblox_to_brewfather.yml: ",sys.exc_info()[0])
+except Exception:
+    print('Error loading confiration file brewblox_to_brewfather.yml: ',
+          sys.exc_info()[0])
     sys.exit()
 
 bfdata = conf['brewfatherdata']
-headers = { 'Content-Type': 'application/json' }
-urllib3.disable_warnings()
+brewblox_url = conf['brewblox']['url']
+metrics_url = f'{brewblox_url}/history/timeseries/metrics'
+brewblox_params = {'fields': list(conf['brewblox']['fields'].values())}
 
-# List of fields accross devices
-fields = {}
-for device in conf['brewblox']['devices']:
-    for measurement, devicefields in device.items():
-        for f,v in devicefields.items():
-            fields[f] = v
+# Key is brewblox field, value is brewfather field
+reverse_fields = {
+    v: k
+    for k, v in conf['brewblox']['fields'].items()
+}
 
 while True:
-    timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-    # Query Brewblox for each device
-    for device in conf['brewblox']['devices']:
-        for measurement,devicefields in device.items():
-            brewblox_params = { 'measurement': measurement, 'fields': list(devicefields.values()) }
-            response = requests.post(conf['brewblox']['url'], json=brewblox_params, headers=headers, verify=False)
-            if response.status_code == 200:
-                for r in response.json():
-                    field = fieldSearch(r['field'])
-                    if field:
-                        bfdata[field] = r['value']
-                    else:
-                        print(timestamp+" Field "+r['field']+" not recognized")
+    timestamp = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+
+    # Query Brewblox fields
+    response = requests.post(metrics_url, json=brewblox_params, verify=False)
+
+    if response.status_code == 200:
+        for response_value in response.json():
+            brewblox_field = response_value['metric']
+            brewfather_field = reverse_fields.get(brewblox_field)
+            if brewfather_field in bfdata:
+                bfdata[brewfather_field] = response_value['value']
+            else:
+                print(f'{timestamp} Field {brewfather_field} not recognized')
+
+    else:
+        print(f'{timestamp} Request to Brewblox API failed' +
+              f' with HTTP error {response.status_code} {response.text}')
 
     # Write to brewfather
-    brewfather_params = removeNone(bfdata)
-    bf_response = requests.post(conf['brewfather']['url'], json=brewfather_params, headers=headers, verify=False)
+    brewfather_params = {
+        k: v
+        for k, v in bfdata.items()
+        if v is not None
+    }
+
+    bf_response = requests.post(conf['brewfather']['url'],
+                                json=brewfather_params,
+                                verify=False)
     if bf_response.status_code == 200:
         result = bf_response.json()['result']
-        if result == "success":
-            print(timestamp+" Data submitted succesfully")
-        elif result == "ignored":
-            print(timestamp+" Data submission ignored (leave 900 seconds between logging)")
+        if result == 'success':
+            print(f'{timestamp} Data submitted succesfully')
+        elif result == 'ignored':
+            print(f'{timestamp} Data submission ignored' +
+                  ' (leave 900 seconds between logging)')
         else:
-            print(timestamp+" "+bf_response.text)
+            print(f'{timestamp} {bf_response.text}')
     else:
-        print(timestamp+" Request to Brewfather API failed with HTTP error code "+bf_response.status_code)
+        print(f'{timestamp} Request to Brewfather API failed' +
+              f' with HTTP error code {bf_response.status_code}')
 
     if conf['brewfather']['interval'] != 0:
         time.sleep(conf['brewfather']['interval'])


### PR DESCRIPTION
The Brewblox history database changed in the 2021/08/02 release, and with it the API.
The primary difference is that the concept of "measurements" has disappeared. Fields are not nested, and include the service in their name.

Changes to the script:
- formatted with flake8/autopep8 using default settings and single quotes
- f-strings are used to format strings, as python 3.5 is no longer supported
- if the brewblox API has a non-200 response, it is now printed
- rewrote querying brewblox fields to use the new API and response data format
- inlined the `fieldSearch()` and `removeNone()` functions
- removed explicit json headers as they are automatically set by `requests` when using the `json=` keyword argument.

Changes to the configuration format
- `brewblox.url` is now the base URL, without the path to the history API
- `brewblox.measurements.fields` has been flattened to `brewblox.fields`, with field names including the service name.
- replaced the 'None' strings in `brewfatherdata` with null values.